### PR TITLE
perf: replace Tone.js with native Web Audio engine + memoize hot UI paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.1",
-        "@rollup/rollup-linux-x64-gnu": "*",
         "file-saver": "^2.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
         "react-redux": "^9.1.0",
-        "tone": "^14.7.77",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -368,17 +366,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1341,18 +1328,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/automation-events": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.0.1.tgz",
-      "integrity": "sha512-Fmwxv+L19DdpGSrnXVHfFnEqhPFnGBMP3aZNvogDmgRu9nVCgh0iycb3bRcklYkd0FBp+khGk+JeVYcBx0Yzdg==",
-      "dependencies": {
-        "@babel/runtime": "^7.24.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.2.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -3216,11 +3191,6 @@
         "redux": "^5.0.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/reselect": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
@@ -3435,16 +3405,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/standardized-audio-context": {
-      "version": "25.3.65",
-      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.65.tgz",
-      "integrity": "sha512-FuEbb2ARuPeb1D7nGNG12ZqdUTLEaK8DXaBk/IfsRjW9qI+rwFKf6Znud9+XBrZmQOByenZLeJfiQnAC7OQOhg==",
-      "dependencies": {
-        "@babel/runtime": "^7.24.0",
-        "automation-events": "^7.0.1",
-        "tslib": "^2.6.2"
       }
     },
     "node_modules/string-width": {
@@ -3711,15 +3671,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tone": {
-      "version": "14.7.77",
-      "resolved": "https://registry.npmjs.org/tone/-/tone-14.7.77.tgz",
-      "integrity": "sha512-tCfK73IkLHyzoKUvGq47gyDyxiKLFvKiVCOobynGgBB9Dl0NkxTM2p+eRJXyCYrjJwy9Y0XCMqD3uOYsYt2Fdg==",
-      "dependencies": {
-        "standardized-audio-context": "^25.1.8",
-        "tslib": "^2.0.1"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
@@ -3737,11 +3688,6 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "react-redux": "^9.1.0",
-    "tone": "^14.7.77",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/src/features/daw/common/components/ruler/ruler.tsx
+++ b/src/features/daw/common/components/ruler/ruler.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { RULER_BAR_WIDTH, SUB_BAR_NUM } from './constants'
 import { selectMaxBars } from '../../../playlist-header/store/selectors'
@@ -5,71 +6,67 @@ import { requestNewTickPosition } from '../../../playlist-header/store/playlist-
 import { TICK_WIDTH_PIXEL } from '../../../playlist/constants'
 import { usePreviewLoopSafeTransportPosition } from '../../hooks/use-preview-loop-safe-transport-position'
 
-type RulerBarProps = {
+type RulerSubBarProps = {
   barIndex: number
-  maxBars: number
-  currentTick: number
+  subBarIndex: number
   onSelectTick: (tick: number) => void
 }
 
-const RulerSubBar = ({
-  barIndex,
-  subBarIndex,
-  onSelectTick,
-}: {
-  subBarIndex: number
-} & RulerBarProps) => {
-  const tick = barIndex * SUB_BAR_NUM * 4 + subBarIndex * 4
-  return (
-    <div
-      key={subBarIndex}
-      className={`w-full relative border-slate-400 ${
-        subBarIndex == SUB_BAR_NUM - 1 ? '' : 'border-r'
-      }`}
-      onClick={() => onSelectTick(tick)}
-    ></div>
-  )
+const RulerSubBar = memo(
+  ({ barIndex, subBarIndex, onSelectTick }: RulerSubBarProps) => {
+    const tick = barIndex * SUB_BAR_NUM * 4 + subBarIndex * 4
+    return (
+      <div
+        className={`w-full relative border-slate-400 ${
+          subBarIndex == SUB_BAR_NUM - 1 ? '' : 'border-r'
+        }`}
+        onClick={() => onSelectTick(tick)}
+      ></div>
+    )
+  }
+)
+
+type RulerBarProps = {
+  barIndex: number
+  maxBars: number
+  onSelectTick: (tick: number) => void
 }
 
-const RulerBar = ({
-  barIndex,
-  maxBars,
-  currentTick,
-  onSelectTick,
-}: RulerBarProps) => {
-  return (
-    <div
-      key={barIndex + 1}
-      className={`flex flex-col justify-end gap-4 w-[${RULER_BAR_WIDTH}px] border-l border-slate-700 dark:border-slate-400 ${
-        barIndex == maxBars - 1 ? 'border-r' : ''
-      }`}
-    >
-      <div className="px-2 text-slate-700 dark:text-slate-400  select-none">
-        {barIndex + 1}
-      </div>
+const RulerBar = memo(
+  ({ barIndex, maxBars, onSelectTick }: RulerBarProps) => {
+    return (
+      <div
+        className={`flex flex-col justify-end gap-4 w-[${RULER_BAR_WIDTH}px] border-l border-slate-700 dark:border-slate-400 ${
+          barIndex == maxBars - 1 ? 'border-r' : ''
+        }`}
+      >
+        <div className="px-2 text-slate-700 dark:text-slate-400  select-none">
+          {barIndex + 1}
+        </div>
 
-      <div className="flex flex-row h-[40%]">
-        {Array.from({ length: SUB_BAR_NUM }).map((_, j) => (
-          <RulerSubBar
-            key={j}
-            barIndex={barIndex}
-            maxBars={maxBars}
-            subBarIndex={j}
-            currentTick={currentTick}
-            onSelectTick={onSelectTick}
-          />
-        ))}
+        <div className="flex flex-row h-[40%]">
+          {Array.from({ length: SUB_BAR_NUM }).map((_, j) => (
+            <RulerSubBar
+              key={j}
+              barIndex={barIndex}
+              subBarIndex={j}
+              onSelectTick={onSelectTick}
+            />
+          ))}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)
 
-const RulerThumb = ({ currentTick }: { currentTick: number }) => {
+// Self-subscribing playhead — isolates per-tick re-renders away from the grid.
+const RulerThumb = () => {
+  const { tick } = usePreviewLoopSafeTransportPosition()
   // -7 is the offset to center the thumb (probably depending on the border width)
-  const leftOffset = currentTick * TICK_WIDTH_PIXEL - 7
+  const leftOffset = tick * TICK_WIDTH_PIXEL - 7
   return (
     <div
-      className="absolute bottom-0 w-0 h-0 
+      className="absolute bottom-0 w-0 h-0
   border-l-[8px] border-l-transparent
   border-t-[17px] border-t-black dark:border-t-white
   border-r-[8px] border-r-transparent"
@@ -78,29 +75,44 @@ const RulerThumb = ({ currentTick }: { currentTick: number }) => {
   )
 }
 
-export const Ruler = () => {
-  const maxBars = useSelector(selectMaxBars)
-  const { tick: currentTick } = usePreviewLoopSafeTransportPosition()
-  const dispatch = useDispatch()
-
-  const handleSelectTick = (tick: number) => {
-    dispatch(requestNewTickPosition(tick))
-  }
-
-  return (
-    <div className="relative">
+const RulerGrid = memo(
+  ({
+    maxBars,
+    onSelectTick,
+  }: {
+    maxBars: number
+    onSelectTick: (tick: number) => void
+  }) => {
+    return (
       <div className="h-full flex flex-row bg-slate-100 dark:bg-slate-900">
         {Array.from({ length: maxBars }).map((_, i) => (
           <RulerBar
             key={i}
             barIndex={i}
             maxBars={maxBars}
-            currentTick={currentTick}
-            onSelectTick={handleSelectTick}
+            onSelectTick={onSelectTick}
           />
         ))}
       </div>
-      <RulerThumb currentTick={currentTick} />
+    )
+  }
+)
+
+export const Ruler = () => {
+  const maxBars = useSelector(selectMaxBars)
+  const dispatch = useDispatch()
+
+  const handleSelectTick = useCallback(
+    (tick: number) => {
+      dispatch(requestNewTickPosition(tick))
+    },
+    [dispatch]
+  )
+
+  return (
+    <div className="relative">
+      <RulerGrid maxBars={maxBars} onSelectTick={handleSelectTick} />
+      <RulerThumb />
     </div>
   )
 }

--- a/src/features/daw/drum-machine/pad/grid/drum-machine-pad-grid.tsx
+++ b/src/features/daw/drum-machine/pad/grid/drum-machine-pad-grid.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { TrackDrumPatternSound } from '../../../../../model/track/drums/track-drums'
 import { selectCurrentTick } from '../../../playlist-header/store/selectors'
@@ -22,6 +23,24 @@ export const DrumMachinePadGrid = ({
 
   const activeTickBar = previewLoopPlayingTrackId ? currentTick : null
 
+  const handleSoundChange = useCallback(
+    (
+      toChangeSoundIndex: number,
+      toChangeBeatIndex: number,
+      newValue: TrackDrumPatternSound
+    ) => {
+      const newPattern = selectedPatternBeats.map((soundBeats, soundIndex) =>
+        soundIndex === toChangeSoundIndex
+          ? soundBeats.map((sound, beatIndex) =>
+              beatIndex === toChangeBeatIndex ? newValue : sound
+            )
+          : soundBeats
+      )
+      onUpdateCurrentPattern(newPattern)
+    },
+    [selectedPatternBeats, onUpdateCurrentPattern]
+  )
+
   return (
     <div className="flex flex-col gap-1">
       {selectedPatternBeats.map((patternSounds, soundIndex) => (
@@ -30,17 +49,7 @@ export const DrumMachinePadGrid = ({
           patternSounds={patternSounds}
           activeTickBar={activeTickBar}
           soundIndex={soundIndex}
-          onSoundChange={(toChangeSoundIndex, toChangeBeatIndex, newValue) => {
-            const newPattern = selectedPatternBeats.map(
-              (soundBeats, soundIndex) =>
-                soundIndex === toChangeSoundIndex
-                  ? soundBeats.map((sound, beatIndex) =>
-                      beatIndex === toChangeBeatIndex ? newValue : sound
-                    )
-                  : soundBeats
-            )
-            onUpdateCurrentPattern(newPattern)
-          }}
+          onSoundChange={handleSoundChange}
         />
       ))}
     </div>

--- a/src/features/daw/drum-machine/pad/grid/pattern/drum-machine-pad-pattern.tsx
+++ b/src/features/daw/drum-machine/pad/grid/pattern/drum-machine-pad-pattern.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { TrackDrumPatternSound } from '../../../../../../model/track/drums/track-drums'
 import { TRACK_COLORS } from '../../../../../../model/track/track-color'
 
@@ -12,7 +13,7 @@ export type DrumMachinePadPatternProps = {
   ) => void
 }
 
-export const DrumMachinePadPattern = ({
+const DrumMachinePadPatternComponent = ({
   patternSounds,
   soundIndex,
   onSoundChange,
@@ -50,3 +51,5 @@ export const DrumMachinePadPattern = ({
     </div>
   )
 }
+
+export const DrumMachinePadPattern = memo(DrumMachinePadPatternComponent)

--- a/src/features/daw/playlist/track-list/track-list.tsx
+++ b/src/features/daw/playlist/track-list/track-list.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { TrackItem } from './track-item/track-item'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectSelectedTrack, selectTracks } from '../store/selectors'
@@ -11,23 +12,56 @@ import {
 export const TrackList = () => {
   const tracks = useSelector(selectTracks)
   const selectedTrack = useSelector(selectSelectedTrack)
-  const dipatch = useDispatch()
-  const handleSelectTrack = (track: Track) => {
-    dipatch(selectTrack(track))
-  }
+  const dispatch = useDispatch()
+
+  const handleSelectTrack = useCallback(
+    (track: Track) => {
+      dispatch(selectTrack(track))
+    },
+    [dispatch]
+  )
 
   return (
     <div className="flex flex-col gap-1 w-full">
       {tracks.map((track: Track) => (
-        <TrackItem
+        <TrackListRow
           key={track.id}
           track={track}
           selectedTrack={selectedTrack}
           onSelectTrack={handleSelectTrack}
-          onToggleMute={() => dipatch(toggleTrackMute(track.id))}
-          onToggleSolo={() => dipatch(toggleTrackSolo(track.id))}
         />
       ))}
     </div>
+  )
+}
+
+// Row wrapper so each row's mute/solo callbacks are stable per-track and
+// a `TrackItem` render is not caused by unrelated rows dispatching actions.
+const TrackListRow = ({
+  track,
+  selectedTrack,
+  onSelectTrack,
+}: {
+  track: Track
+  selectedTrack?: Track | null
+  onSelectTrack: (track: Track) => void
+}) => {
+  const dispatch = useDispatch()
+  const handleToggleMute = useCallback(
+    () => dispatch(toggleTrackMute(track.id)),
+    [dispatch, track.id]
+  )
+  const handleToggleSolo = useCallback(
+    () => dispatch(toggleTrackSolo(track.id)),
+    [dispatch, track.id]
+  )
+  return (
+    <TrackItem
+      track={track}
+      selectedTrack={selectedTrack}
+      onSelectTrack={onSelectTrack}
+      onToggleMute={handleToggleMute}
+      onToggleSolo={handleToggleSolo}
+    />
   )
 }

--- a/src/sequencer/audio/buffer-cache.ts
+++ b/src/sequencer/audio/buffer-cache.ts
@@ -1,0 +1,18 @@
+import { getAudioContext } from './engine'
+
+const _cache: Map<string, Promise<AudioBuffer>> = new Map()
+
+export function loadSample(url: string): Promise<AudioBuffer> {
+  const cached = _cache.get(url)
+  if (cached) return cached
+  const promise = (async () => {
+    const response = await fetch(url)
+    const arrayBuffer = await response.arrayBuffer()
+    const ctx = getAudioContext()
+    return await ctx.decodeAudioData(arrayBuffer)
+  })()
+  _cache.set(url, promise)
+  // If the fetch fails, drop the rejection from the cache so a retry is possible
+  promise.catch(() => _cache.delete(url))
+  return promise
+}

--- a/src/sequencer/audio/engine.ts
+++ b/src/sequencer/audio/engine.ts
@@ -1,0 +1,47 @@
+let _ctx: AudioContext | null = null
+let _master: GainNode | null = null
+
+type WindowWithWebkit = Window & {
+  webkitAudioContext?: typeof AudioContext
+}
+
+export function getAudioContext(): AudioContext {
+  if (!_ctx) {
+    const Ctor =
+      window.AudioContext || (window as WindowWithWebkit).webkitAudioContext
+    if (!Ctor) {
+      throw new Error('Web Audio API is not supported in this browser')
+    }
+    _ctx = new Ctor()
+  }
+  return _ctx
+}
+
+export function getMasterGain(): GainNode {
+  if (!_master) {
+    const ctx = getAudioContext()
+    _master = ctx.createGain()
+    _master.gain.value = 1
+    _master.connect(ctx.destination)
+  }
+  return _master
+}
+
+export async function startAudio(): Promise<void> {
+  const ctx = getAudioContext()
+  // Ensure master gain is created eagerly so it's ready to connect to
+  getMasterGain()
+  if (ctx.state === 'suspended') {
+    await ctx.resume()
+  }
+}
+
+export function gainToDb(gain: number): number {
+  if (gain <= 0) return -Infinity
+  return 20 * Math.log10(gain)
+}
+
+export function dbToGain(db: number): number {
+  if (!isFinite(db)) return 0
+  return Math.pow(10, db / 20)
+}

--- a/src/sequencer/audio/note-frequency.ts
+++ b/src/sequencer/audio/note-frequency.ts
@@ -1,0 +1,35 @@
+import { Key } from '../../model/note/key/key'
+
+// MIDI number for C1 in the KEYS array (KEYS[0]). We use the common mapping where
+// A4 = MIDI 69 = 440 Hz, so C1 = MIDI 24.
+const C1_MIDI = 24
+const NOTE_INDEX: Record<string, number> = {
+  C: 0,
+  'C#': 1,
+  D: 2,
+  'D#': 3,
+  E: 4,
+  F: 5,
+  'F#': 6,
+  G: 7,
+  'G#': 8,
+  A: 9,
+  'A#': 10,
+  B: 11,
+}
+
+export function keyToMidi(key: Key): number {
+  // key is like "C1", "C#1", "D2", "F#10"
+  const match = /^([A-G]#?)(-?\d+)$/.exec(key)
+  if (!match) return C1_MIDI
+  const noteIdx = NOTE_INDEX[match[1]]
+  const octave = parseInt(match[2], 10)
+  // In the KEYS array, "C1" is octave label "1", but in MIDI convention
+  // C1 = 24. Maintain that mapping consistently.
+  return (octave + 1) * 12 + noteIdx
+}
+
+export function keyToFrequency(key: Key): number {
+  const midi = keyToMidi(key)
+  return 440 * Math.pow(2, (midi - 69) / 12)
+}

--- a/src/sequencer/audio/transport.ts
+++ b/src/sequencer/audio/transport.ts
@@ -1,0 +1,251 @@
+import { getAudioContext } from './engine'
+
+export type PartEvent<T = unknown> = {
+  tick: number
+  value: T
+}
+
+export type PartCallback<T = unknown> = (time: number, value: T) => void
+
+export class Part<T = unknown> {
+  startAtTick: number = 0
+  events: PartEvent<T>[] = []
+  callback: PartCallback<T>
+
+  constructor(callback: PartCallback<T>, events: PartEvent<T>[] = []) {
+    this.callback = callback
+    this.events = events.slice().sort((a, b) => a.tick - b.tick)
+  }
+
+  start(startAtTick: number): this {
+    this.startAtTick = startAtTick
+    transport.addPart(this as Part<unknown>)
+    return this
+  }
+
+  dispose(): void {
+    transport.removePart(this as Part<unknown>)
+    this.events = []
+  }
+}
+
+type RepeatEntry = {
+  id: number
+  intervalTicks: number
+  startTick: number
+  callback: (time: number) => void
+  muted: boolean
+}
+
+const LOOKAHEAD_SEC = 0.1
+const SCHEDULE_INTERVAL_MS = 25
+// Number of 16th-note ticks per whole note. `tick` in this codebase is a 16th note.
+const TICKS_PER_BEAT = 4
+
+class Transport {
+  bpm = 120
+  loop = false
+  loopStartTicks = 0
+  loopEndTicks = 16
+
+  state: 'started' | 'stopped' | 'paused' = 'stopped'
+
+  // origin = at audioTime `_originAudioTime`, the playback position was `_originTick`
+  private _originAudioTime = 0
+  private _originTick = 0
+
+  // scheduler cursor
+  private _nextTick = 0
+  private _nextTickTime = 0
+
+  private _nextRepeatId = 1
+  private _repeats: Map<number, RepeatEntry> = new Map()
+  private _parts: Set<Part<unknown>> = new Set()
+
+  private _schedulerHandle: ReturnType<typeof setInterval> | null = null
+
+  secondsPerTick(): number {
+    return 60 / this.bpm / TICKS_PER_BEAT
+  }
+
+  get positionTicks(): number {
+    if (this.state !== 'started') return this._originTick
+    const ctx = getAudioContext()
+    const elapsed = ctx.currentTime - this._originAudioTime
+    const raw = this._originTick + elapsed / this.secondsPerTick()
+    if (this.loop) {
+      const len = this.loopEndTicks - this.loopStartTicks
+      if (len > 0 && raw >= this.loopEndTicks) {
+        return ((raw - this.loopStartTicks) % len) + this.loopStartTicks
+      }
+    }
+    return raw
+  }
+
+  get seconds(): number {
+    return Math.max(this.positionTicks * this.secondsPerTick(), 0)
+  }
+
+  setBpm(bpm: number): void {
+    if (bpm <= 0) return
+    if (this.state === 'started') {
+      // preserve current position when tempo changes
+      const current = this.positionTicks
+      const ctx = getAudioContext()
+      this._originAudioTime = ctx.currentTime
+      this._originTick = current
+      this.bpm = bpm
+      // re-align the scheduler cursor to the current time
+      const spt = this.secondsPerTick()
+      this._nextTick = Math.ceil(current)
+      this._nextTickTime =
+        this._originAudioTime + (this._nextTick - current) * spt
+    } else {
+      this.bpm = bpm
+    }
+  }
+
+  seekTicks(tick: number): void {
+    const ctx = getAudioContext()
+    this._originTick = Math.max(0, tick)
+    this._originAudioTime = ctx.currentTime
+    this._nextTick = Math.ceil(this._originTick)
+    this._nextTickTime =
+      this._originAudioTime +
+      (this._nextTick - this._originTick) * this.secondsPerTick()
+  }
+
+  start(): void {
+    if (this.state === 'started') return
+    const ctx = getAudioContext()
+    // lookahead start so we don't miss the first beat
+    const startDelay = 0.02
+    this._originAudioTime = ctx.currentTime + startDelay
+    // keep _originTick — resume from current position
+    this._nextTick = Math.ceil(this._originTick)
+    this._nextTickTime =
+      this._originAudioTime +
+      (this._nextTick - this._originTick) * this.secondsPerTick()
+    this.state = 'started'
+    this._startSchedulerLoop()
+  }
+
+  stop(): void {
+    const ctx = getAudioContext()
+    this.state = 'stopped'
+    this._originTick = 0
+    this._originAudioTime = ctx.currentTime
+    this._nextTick = 0
+    this._nextTickTime = ctx.currentTime
+    this._stopSchedulerLoop()
+  }
+
+  pause(): void {
+    if (this.state !== 'started') return
+    const current = this.positionTicks
+    const ctx = getAudioContext()
+    this._originTick = current
+    this._originAudioTime = ctx.currentTime
+    this.state = 'paused'
+    this._stopSchedulerLoop()
+  }
+
+  scheduleRepeat(
+    callback: (time: number) => void,
+    intervalTicks: number,
+    startTick = 0
+  ): number {
+    const id = this._nextRepeatId++
+    this._repeats.set(id, {
+      id,
+      intervalTicks: Math.max(1, Math.round(intervalTicks)),
+      startTick,
+      callback,
+      muted: false,
+    })
+    return id
+  }
+
+  clearRepeat(id: number): void {
+    this._repeats.delete(id)
+  }
+
+  muteRepeat(id: number, muted: boolean): void {
+    const rep = this._repeats.get(id)
+    if (rep) rep.muted = muted
+  }
+
+  addPart(part: Part<unknown>): void {
+    this._parts.add(part)
+  }
+
+  removePart(part: Part<unknown>): void {
+    this._parts.delete(part)
+  }
+
+  private _startSchedulerLoop(): void {
+    if (this._schedulerHandle !== null) return
+    // Prime run to schedule immediate events before the first interval tick
+    this._scheduleTick()
+    this._schedulerHandle = setInterval(
+      () => this._scheduleTick(),
+      SCHEDULE_INTERVAL_MS
+    )
+  }
+
+  private _stopSchedulerLoop(): void {
+    if (this._schedulerHandle !== null) {
+      clearInterval(this._schedulerHandle)
+      this._schedulerHandle = null
+    }
+  }
+
+  private _scheduleTick(): void {
+    const ctx = getAudioContext()
+    const deadline = ctx.currentTime + LOOKAHEAD_SEC
+    const spt = this.secondsPerTick()
+
+    while (this._nextTickTime < deadline) {
+      const currentTick = this._nextTick
+      const time = this._nextTickTime
+
+      // Repeats
+      for (const rep of this._repeats.values()) {
+        if (rep.muted) continue
+        if (currentTick < rep.startTick) continue
+        if ((currentTick - rep.startTick) % rep.intervalTicks === 0) {
+          rep.callback(time)
+        }
+      }
+
+      // Parts
+      for (const part of this._parts) {
+        const relTick = currentTick - part.startAtTick
+        if (relTick < 0) continue
+        // linear scan — parts are small in practice (<= a bar of notes)
+        const events = part.events
+        for (let i = 0; i < events.length; i++) {
+          if (events[i].tick === relTick) {
+            part.callback(time, events[i].value)
+          } else if (events[i].tick > relTick) {
+            break
+          }
+        }
+      }
+
+      // Advance
+      this._nextTick += 1
+      this._nextTickTime += spt
+
+      // Loop wrap
+      if (this.loop && this._nextTick >= this.loopEndTicks) {
+        this._nextTick = this.loopStartTicks
+        // anchor the origin so `positionTicks` stays accurate after the wrap
+        this._originAudioTime = this._nextTickTime
+        this._originTick = this.loopStartTicks
+      }
+    }
+  }
+}
+
+export const transport = new Transport()

--- a/src/sequencer/channel/channel.ts
+++ b/src/sequencer/channel/channel.ts
@@ -2,17 +2,23 @@ import { Bar } from '../../model/bar/bar'
 import { InstrumentPreset } from '../../model/instrument/preset/preset'
 import { Note } from '../../model/note/note'
 import { Track } from '../../model/track/track'
-import * as Tone from 'tone'
 import { TimeUtils } from '../time/utils/time-utils'
 import { ChannelInstrument } from './instrument/channel-instrument'
 import { createChannelInstrument } from './instrument/channel-instrument-factory'
 import { Key } from '../../model/note/key/key'
+import { Part } from '../audio/transport'
+
+type PartNoteValue = {
+  duration: string
+  note: Key
+  velocity: number
+}
 
 export class Channel {
   trackId: string
 
-  private _parts: Tone.Part[] = []
-  private _previewLoopPart: Tone.Part | null = null
+  private _parts: Part<PartNoteValue>[] = []
+  private _previewLoopPart: Part<PartNoteValue> | null = null
   private _instrument: ChannelInstrument | null = null
   private _muted: boolean
 
@@ -63,16 +69,20 @@ export class Channel {
     this._parts = trackBars.map((bar) => this.partFromBar(bar))
   }
 
-  partFromBar(bar: Bar, isPreviewLoopBar: boolean = false) {
-    const sequencerNotes = bar.notes.map(this.noteToTone.bind(this))
-    const part = new Tone.Part(
-      (time, value: ReturnType<typeof this.noteToTone>) => {
-        if (!this._canPlayPartNote(isPreviewLoopBar)) return
-        this._instrument?.play(value.note, value.duration, time, value.velocity)
+  partFromBar(bar: Bar, isPreviewLoopBar: boolean = false): Part<PartNoteValue> {
+    const events = bar.notes.map((note) => ({
+      tick: note.startsAtRelativeTick,
+      value: {
+        duration: TimeUtils.tickToToneTime(note.durationTicks),
+        note: note.key,
+        velocity: note.velocity / 100,
       },
-      sequencerNotes
-    )
-    part.start(TimeUtils.tickToToneTime(bar.startAtTick))
+    }))
+    const part = new Part<PartNoteValue>((time, value) => {
+      if (!this._canPlayPartNote(isPreviewLoopBar)) return
+      this._instrument?.play(value.note, value.duration, time, value.velocity)
+    }, events)
+    part.start(bar.startAtTick)
     return part
   }
 
@@ -103,6 +113,7 @@ export class Channel {
     return true
   }
 
+  // kept for parity with the previous API — consumers may still import it.
   noteToTone(note: Note) {
     return {
       time: TimeUtils.tickToToneTime(note.startsAtRelativeTick),

--- a/src/sequencer/channel/channel.ts
+++ b/src/sequencer/channel/channel.ts
@@ -25,6 +25,13 @@ export class Channel {
   private _otherTrackIsPreviewing: boolean = false
   private _isPreviewingLoop: boolean = false
 
+  // Cached references from the last applied track. Compared with the next
+  // track via Immer's structural sharing so we only mutate the audio graph
+  // for the parts that actually changed (preset / bars / volume / mute).
+  private _lastPresetId: string | null = null
+  private _lastBars: Readonly<Bar[]> | null = null
+  private _lastVolume: number | null = null
+
   constructor(track: Track) {
     this.trackId = track.id
     this._muted = false
@@ -32,17 +39,44 @@ export class Channel {
   }
 
   updateFromTrack(track: Track) {
-    if (!this.hasChanged(track)) {
-      return
-    }
-    this.clear()
+    const presetChanged = this._lastPresetId !== track.instrumentPreset.id
+    const barsChanged = this._lastBars !== track.bars
+    const volumeChanged = this._lastVolume !== track.volume
+
+    // Mute / solo: cheap flag flip, always safe to apply.
     this.setMuted(
       track.muted || (track.areThereAnyOtherTrackSoloed && !track.soloed)
     )
-    this.setInstrument(track.instrumentPreset)
-    this.generatePartsFromBars(track.bars)
-    this.setVolume(track.volume)
-    this.connect()
+
+    if (presetChanged) {
+      // Replacing the instrument is the only path that disconnects audio
+      // nodes, so confine it to actual preset changes (rare).
+      this._instrument?.disconnect()
+      this._parts.forEach((p) => p.dispose())
+      this._parts = []
+      this.setInstrument(track.instrumentPreset)
+      this.connect()
+      this._lastPresetId = track.instrumentPreset.id
+      // After a fresh instrument we must recreate parts and resend volume
+      this.generatePartsFromBars(track.bars)
+      this._lastBars = track.bars
+      this.setVolume(track.volume)
+      this._lastVolume = track.volume
+      return
+    }
+
+    if (barsChanged) {
+      // Swap parts in place — instrument stays connected, no audio dropout.
+      this._parts.forEach((p) => p.dispose())
+      this._parts = []
+      this.generatePartsFromBars(track.bars)
+      this._lastBars = track.bars
+    }
+
+    if (volumeChanged) {
+      this.setVolume(track.volume)
+      this._lastVolume = track.volume
+    }
   }
 
   setVolume(volume: number) {
@@ -60,8 +94,12 @@ export class Channel {
   clear() {
     this._parts.forEach((part) => part.dispose())
     this._parts = []
-
+    this._previewLoopPart?.dispose()
+    this._previewLoopPart = null
     this._instrument?.disconnect()
+    this._lastPresetId = null
+    this._lastBars = null
+    this._lastVolume = null
   }
 
   generatePartsFromBars(trackBars: Readonly<Bar[]>) {
@@ -105,12 +143,6 @@ export class Channel {
 
   connect() {
     this._instrument?.connect()
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  hasChanged(_newTrack: Track) {
-    // TODO compare new track with the current settings (maybe trying with an hash of the track?)
-    return true
   }
 
   // kept for parity with the previous API — consumers may still import it.

--- a/src/sequencer/channel/instrument/sampler/sampler-instrument.ts
+++ b/src/sequencer/channel/instrument/sampler/sampler-instrument.ts
@@ -1,38 +1,125 @@
 import { Key } from '../../../../model/note/key/key'
+import { getAudioContext, getMasterGain, dbToGain } from '../../../audio/engine'
+import { loadSample } from '../../../audio/buffer-cache'
+import { keyToMidi } from '../../../audio/note-frequency'
 import { Volume } from '../../../volume/volume'
 import { ChannelInstrument } from '../channel-instrument'
-import * as Tone from 'tone'
 
 export type SamplerInstrumentSound = {
   key: Key
   sampleUrl: string
 }
 
+type SamplerSlot = {
+  key: Key
+  midi: number
+  url: string
+  buffer: AudioBuffer | null
+}
+
 export default class SamplerInstrument implements ChannelInstrument {
-  _sampler: Tone.Sampler
+  private _gain: GainNode
+  private _slots: SamplerSlot[] = []
+  private _slotsByKey: Map<Key, SamplerSlot> = new Map()
+  private _connected = false
 
   constructor(sounds: SamplerInstrumentSound[]) {
-    this._sampler = new Tone.Sampler()
-    this._setup(sounds)
+    const ctx = getAudioContext()
+    this._gain = ctx.createGain()
+    this._gain.gain.value = 1
+    this._loadSounds(sounds)
   }
 
   connect(): void {
-    this._sampler.toDestination()
+    if (this._connected) return
+    this._gain.connect(getMasterGain())
+    this._connected = true
   }
+
   disconnect(): void {
-    this._sampler.disconnect()
+    if (!this._connected) return
+    try {
+      this._gain.disconnect()
+    } catch {
+      // already disconnected
+    }
+    this._connected = false
   }
+
   setVolume(volume: number): void {
-    this._sampler.volume.value = Volume.transformVolumeToToneVolume(volume)
+    const db = Volume.transformVolumeToToneVolume(volume)
+    this._gain.gain.setTargetAtTime(
+      dbToGain(db),
+      getAudioContext().currentTime,
+      0.01
+    )
   }
 
-  play(note: Key, duration: string, time?: number, velocity?: number) {
-    this._sampler.triggerAttackRelease(note, duration, time, velocity)
+  play(note: Key, _duration: string, time?: number, velocity?: number): void {
+    const ctx = getAudioContext()
+    const when = time ?? ctx.currentTime
+    const slot = this._findClosestSlot(note)
+    if (!slot || !slot.buffer) return
+
+    const source = ctx.createBufferSource()
+    source.buffer = slot.buffer
+    // Pitch-shift if an exact key match is not available
+    const midi = keyToMidi(note)
+    if (midi !== slot.midi) {
+      source.playbackRate.value = Math.pow(2, (midi - slot.midi) / 12)
+    }
+
+    const gain = ctx.createGain()
+    gain.gain.value = velocity ?? 1
+    source.connect(gain)
+    gain.connect(this._gain)
+
+    try {
+      source.start(when)
+    } catch {
+      // start time was in the past, fall back to immediate playback
+      source.start()
+    }
+    source.onended = () => {
+      try {
+        source.disconnect()
+        gain.disconnect()
+      } catch {
+        // ignore
+      }
+    }
   }
 
-  _setup(sounds: SamplerInstrumentSound[]) {
+  private _loadSounds(sounds: SamplerInstrumentSound[]): void {
     sounds.forEach((sound) => {
-      this._sampler.add(sound.key, sound.sampleUrl)
+      const slot: SamplerSlot = {
+        key: sound.key,
+        midi: keyToMidi(sound.key),
+        url: sound.sampleUrl,
+        buffer: null,
+      }
+      this._slots.push(slot)
+      this._slotsByKey.set(sound.key, slot)
+      loadSample(sound.sampleUrl).then((buf) => {
+        slot.buffer = buf
+      })
     })
+  }
+
+  private _findClosestSlot(key: Key): SamplerSlot | null {
+    const exact = this._slotsByKey.get(key)
+    if (exact) return exact
+    if (this._slots.length === 0) return null
+    const midi = keyToMidi(key)
+    let best = this._slots[0]
+    let bestDist = Math.abs(best.midi - midi)
+    for (let i = 1; i < this._slots.length; i++) {
+      const d = Math.abs(this._slots[i].midi - midi)
+      if (d < bestDist) {
+        best = this._slots[i]
+        bestDist = d
+      }
+    }
+    return best
   }
 }

--- a/src/sequencer/channel/instrument/synth/synth-instrument.ts
+++ b/src/sequencer/channel/instrument/synth/synth-instrument.ts
@@ -1,24 +1,107 @@
 import { Key } from '../../../../model/note/key/key'
+import { getAudioContext, getMasterGain, dbToGain } from '../../../audio/engine'
+import { keyToFrequency } from '../../../audio/note-frequency'
 import { Volume } from '../../../volume/volume'
 import { ChannelInstrument } from '../channel-instrument'
+import { durationStringToSeconds } from '../../../time/utils/time-utils'
 
-import * as Tone from 'tone'
+// A lightweight FM synth voice roughly modelled on the defaults of Tone.FMSynth:
+//   harmonicity = 3 (modulator frequency = carrier * 3)
+//   modulation index ~ 10
+//   ADSR: attack 0.01s, decay 0.3s, sustain 0.4, release 0.4s
+// A fresh voice is allocated per note and torn down when done.
+const HARMONICITY = 3
+const MOD_INDEX = 10
+const ATTACK = 0.01
+const DECAY = 0.3
+const SUSTAIN = 0.4
+const RELEASE = 0.4
 
 export default class SynthInstrument implements ChannelInstrument {
-  _synth: Tone.PolySynth = new Tone.PolySynth(Tone.FMSynth)
+  private _gain: GainNode
+  private _connected = false
 
-  constructor() {}
-
-  play(note: Key, duration: string, time?: number, velocity?: number) {
-    this._synth.triggerAttackRelease(note, duration, time, velocity)
+  constructor() {
+    const ctx = getAudioContext()
+    this._gain = ctx.createGain()
+    this._gain.gain.value = 1
   }
+
   connect(): void {
-    this._synth.toDestination()
+    if (this._connected) return
+    this._gain.connect(getMasterGain())
+    this._connected = true
   }
+
   disconnect(): void {
-    this._synth.disconnect()
+    if (!this._connected) return
+    try {
+      this._gain.disconnect()
+    } catch {
+      // ignore
+    }
+    this._connected = false
   }
+
   setVolume(volume: number): void {
-    this._synth.volume.value = Volume.transformVolumeToToneVolume(volume)
+    const db = Volume.transformVolumeToToneVolume(volume)
+    this._gain.gain.setTargetAtTime(
+      dbToGain(db),
+      getAudioContext().currentTime,
+      0.01
+    )
+  }
+
+  play(note: Key, duration: string, time?: number, velocity?: number): void {
+    const ctx = getAudioContext()
+    const when = Math.max(time ?? ctx.currentTime, ctx.currentTime)
+    const durSec = Math.max(durationStringToSeconds(duration), 0.05)
+    const vel = velocity ?? 1
+    const freq = keyToFrequency(note)
+
+    const carrier = ctx.createOscillator()
+    carrier.type = 'sine'
+    carrier.frequency.value = freq
+
+    const modulator = ctx.createOscillator()
+    modulator.type = 'sine'
+    modulator.frequency.value = freq * HARMONICITY
+
+    const modGain = ctx.createGain()
+    modGain.gain.value = freq * MOD_INDEX
+    modulator.connect(modGain)
+    modGain.connect(carrier.frequency)
+
+    const amp = ctx.createGain()
+    amp.gain.value = 0
+    carrier.connect(amp)
+    amp.connect(this._gain)
+
+    const peak = vel
+    const sustainLvl = peak * SUSTAIN
+    const releaseEnd = when + durSec + RELEASE
+
+    // ADSR
+    amp.gain.setValueAtTime(0, when)
+    amp.gain.linearRampToValueAtTime(peak, when + ATTACK)
+    amp.gain.linearRampToValueAtTime(sustainLvl, when + ATTACK + DECAY)
+    amp.gain.setValueAtTime(sustainLvl, when + durSec)
+    amp.gain.linearRampToValueAtTime(0, releaseEnd)
+
+    carrier.start(when)
+    modulator.start(when)
+    carrier.stop(releaseEnd + 0.01)
+    modulator.stop(releaseEnd + 0.01)
+
+    carrier.onended = () => {
+      try {
+        carrier.disconnect()
+        modulator.disconnect()
+        modGain.disconnect()
+        amp.disconnect()
+      } catch {
+        // ignore
+      }
+    }
   }
 }

--- a/src/sequencer/metronome/metronome.ts
+++ b/src/sequencer/metronome/metronome.ts
@@ -1,36 +1,63 @@
-import * as Tone from 'tone'
 import metronomeDown from '../../assets/metronome_down.wav'
 import metronomeUp from '../../assets/metronome_up.wav'
 import { RootStore } from '../../store'
-import { TimeUtils } from '../time/utils/time-utils'
 import { observeStore } from '../../store/observers'
 import { selectMetronomeActive } from '../../features/daw/player-bar/store/selectors'
+import { getAudioContext, getMasterGain } from '../audio/engine'
+import { loadSample } from '../audio/buffer-cache'
+import { transport } from '../audio/transport'
+
+// Ticks per quarter note — the metronome fires on every beat.
+const TICKS_PER_BEAT = 4
 
 export class Metronome {
-  private _playerUp: Tone.Player
-  private _playerDown: Tone.Player
   private _store: RootStore
-  private _loop!: Tone.Loop
+  private _active = false
+  private _upBuffer: AudioBuffer | null = null
+  private _downBuffer: AudioBuffer | null = null
 
   constructor(store: RootStore) {
-    this._playerUp = new Tone.Player(metronomeUp).toDestination()
-    this._playerDown = new Tone.Player(metronomeDown).toDestination()
     this._store = store
+    this._preloadSamples()
 
-    this.setup()
+    transport.scheduleRepeat((time) => {
+      if (!this._active) return
+      const tick = Math.round(transport.positionTicks)
+      const isDownbeat = tick % 16 === 0
+      const buffer = isDownbeat ? this._upBuffer : this._downBuffer
+      if (!buffer) return
+      this._playBuffer(buffer, time)
+    }, TICKS_PER_BEAT)
+
     this.registerStoreListeners()
   }
 
-  setup() {
-    this._loop = new Tone.Loop(() => {
-      const tick = TimeUtils.toneTimeToTicks(Tone.Transport.position)
-      if (Math.floor(tick) % 16 === 0) {
-        this._playerUp.start()
-      } else {
-        this._playerDown.start()
+  private async _preloadSamples() {
+    const [up, down] = await Promise.all([
+      loadSample(metronomeUp),
+      loadSample(metronomeDown),
+    ])
+    this._upBuffer = up
+    this._downBuffer = down
+  }
+
+  private _playBuffer(buffer: AudioBuffer, when: number) {
+    const ctx = getAudioContext()
+    const source = ctx.createBufferSource()
+    source.buffer = buffer
+    source.connect(getMasterGain())
+    try {
+      source.start(when)
+    } catch {
+      source.start()
+    }
+    source.onended = () => {
+      try {
+        source.disconnect()
+      } catch {
+        // ignore
       }
-    }, '4n')
-    this._loop.start(0)
+    }
   }
 
   registerStoreListeners() {
@@ -42,6 +69,6 @@ export class Metronome {
   }
 
   changeMetronomeState(isActive: boolean) {
-    this._loop.mute = !isActive
+    this._active = isActive
   }
 }

--- a/src/sequencer/sequencer.ts
+++ b/src/sequencer/sequencer.ts
@@ -1,7 +1,6 @@
 import { RootStore } from '../store'
 import { observeStore } from '../store/observers'
 
-import * as Tone from 'tone'
 import {
   selectTrackIdInPlayingPreviewloop,
   selectPlayingTrackKeys,
@@ -14,6 +13,12 @@ import { Channel } from './channel/channel'
 import { Clock } from './time/clock/clock'
 import { Metronome } from './metronome/metronome'
 import { Volume } from './volume/volume'
+import { startAudio } from './audio/engine'
+import { transport } from './audio/transport'
+
+// Preview-loop length, in 16th-note ticks (1 measure).
+const PREVIEW_LOOP_TICKS = 16
+
 export default class Sequencer {
   private _store: RootStore
   private _channelsByTrackID: Map<string, Channel> = new Map()
@@ -71,9 +76,9 @@ export default class Sequencer {
           this._lastClockPositionBeforeLoop = this._clock.currentTick
           this._clock.requestNewTickPosition(0)
 
-          Tone.Transport.loop = true
-          Tone.Transport.loopStart = 0
-          Tone.Transport.loopEnd = '1m'
+          transport.loop = true
+          transport.loopStartTicks = 0
+          transport.loopEndTicks = PREVIEW_LOOP_TICKS
 
           this._channelsByTrackID.forEach((channel) => {
             if (channel.trackId === previewLoopPlayingTrackId) {
@@ -87,7 +92,7 @@ export default class Sequencer {
           this.startTracks()
         } else {
           this.stop()
-          Tone.Transport.loop = false
+          transport.loop = false
           this._clock.requestNewTickPosition(this._lastClockPositionBeforeLoop)
 
           this._channelsByTrackID.forEach((channel) => {
@@ -104,8 +109,8 @@ export default class Sequencer {
   }
 
   async startTracks() {
-    await Tone.start()
-    Tone.Transport.start()
+    await startAudio()
+    transport.start()
   }
 
   generateTracks(newTracks: Readonly<Track[]>) {
@@ -120,10 +125,10 @@ export default class Sequencer {
   }
 
   stop() {
-    Tone.Transport.stop()
+    transport.stop()
   }
 
   pause() {
-    Tone.Transport.pause()
+    transport.pause()
   }
 }

--- a/src/sequencer/time/clock/clock.ts
+++ b/src/sequencer/time/clock/clock.ts
@@ -1,11 +1,13 @@
-import * as Tone from 'tone'
 import { RootStore } from '../../../store'
-import { TimeUtils } from '../utils/time-utils'
 import { setCurrentTickFromSequencer } from '../../../features/daw/playlist-header/store/playlist-header-slice'
 import { setTime } from '../../../features/daw/player-bar/store/playerBarSlice'
 import { observeStore } from '../../../store/observers'
 import { selectRequestedNewTickPosition } from '../../../features/daw/playlist-header/store/selectors'
 import { selectBpm } from '../../../features/daw/player-bar/store/selectors'
+import { transport } from '../../audio/transport'
+
+// Emit UI updates on every 16th note (1 tick).
+const UI_TICK_INTERVAL = 1
 
 export class Clock {
   currentTick: number
@@ -20,11 +22,11 @@ export class Clock {
     this._time = 0
     this.currentTick = 0
 
-    Tone.Transport.bpm.value = this._bpm
+    transport.setBpm(this._bpm)
 
-    Tone.Transport.scheduleRepeat(() => {
+    transport.scheduleRepeat(() => {
       this.handleTick()
-    }, '16n')
+    }, UI_TICK_INTERVAL)
 
     this.registerStoreListeners()
   }
@@ -32,10 +34,10 @@ export class Clock {
   requestNewTickPosition(newTick: number | null) {
     if (newTick === null) return
 
-    Tone.Transport.position = TimeUtils.tickToToneTime(newTick)
-    this.getTickAndTimeFromToneTransport()
+    transport.seekTicks(newTick)
+    this.readPositionFromTransport()
 
-    if (Tone.Transport.state !== 'started') {
+    if (transport.state !== 'started') {
       // will trigger store update ONLY if transport is not playing so to not collide with the handleTick method
       this.notifyStore()
     }
@@ -53,18 +55,17 @@ export class Clock {
 
   private handleRequestedNewBpm(newBpm: number) {
     this._bpm = newBpm
-    Tone.Transport.bpm.value = this._bpm
+    transport.setBpm(this._bpm)
   }
 
   private handleTick() {
-    this.getTickAndTimeFromToneTransport()
+    this.readPositionFromTransport()
     this.notifyStore()
   }
 
-  private getTickAndTimeFromToneTransport() {
-    this.currentTick = TimeUtils.toneTimeToTicks(Tone.Transport.position)
-    // sometimes the transport position is negative, so we need to clamp it to 0
-    this._time = Math.max(Tone.Transport.seconds, 0)
+  private readPositionFromTransport() {
+    this.currentTick = Math.floor(transport.positionTicks)
+    this._time = Math.max(transport.seconds, 0)
   }
 
   private notifyStore() {

--- a/src/sequencer/time/utils/time-utils.ts
+++ b/src/sequencer/time/utils/time-utils.ts
@@ -1,18 +1,50 @@
-import * as Tone from 'tone'
+import { transport } from '../../audio/transport'
+
+// 1 tick = 1 sixteenth note. 16 ticks per measure, 4 ticks per quarter note.
+const TICKS_PER_MEASURE = 16
+const TICKS_PER_QUARTER = 4
 
 export class TimeUtils {
-  static tickToToneTime(tick: number) {
-    const measure = Math.floor(tick / 16)
-    const quarters = Math.floor((tick % 16) / 4)
-    const sixteenths = tick % 4
+  /**
+   * Format a tick count as a "measure:quarter:sixteenth" string to keep parity
+   * with the string representation used elsewhere in the UI state.
+   */
+  static tickToToneTime(tick: number): string {
+    const measure = Math.floor(tick / TICKS_PER_MEASURE)
+    const quarters = Math.floor((tick % TICKS_PER_MEASURE) / TICKS_PER_QUARTER)
+    const sixteenths = tick % TICKS_PER_QUARTER
     return `${measure}:${quarters}:${sixteenths}`
   }
 
-  static toneTimeToTicks(time: Tone.Unit.Time) {
-    const [measures, quarters, sixteenths] = time
+  /**
+   * Parse the same bar:quarter:sixteenth string format back into a tick count.
+   */
+  static toneTimeToTicks(time: string | number): number {
+    if (typeof time === 'number') return time
+    const [measures = 0, quarters = 0, sixteenths = 0] = time
       .toString()
       .split(':')
       .map(Number)
-    return measures * 16 + quarters * 4 + sixteenths
+    return measures * TICKS_PER_MEASURE + quarters * TICKS_PER_QUARTER + sixteenths
   }
+}
+
+/**
+ * Convert a duration string (either "m:q:16" or a Tone-style short notation such
+ * as "8n", "4n", "1m") to seconds using the current transport tempo.
+ */
+export function durationStringToSeconds(duration: string): number {
+  const spt = transport.secondsPerTick()
+  const shortMatch = /^(\d+)(n|m)$/.exec(duration)
+  if (shortMatch) {
+    const value = parseInt(shortMatch[1], 10)
+    const unit = shortMatch[2]
+    if (unit === 'm') {
+      return value * TICKS_PER_MEASURE * spt
+    }
+    // "n" == note division (4n = quarter note, 8n = eighth, 16n = sixteenth)
+    const ticks = (TICKS_PER_MEASURE * 4) / value
+    return ticks * spt
+  }
+  return TimeUtils.toneTimeToTicks(duration) * spt
 }

--- a/src/sequencer/volume/volume.ts
+++ b/src/sequencer/volume/volume.ts
@@ -1,14 +1,18 @@
-import * as Tone from 'tone'
 import { RootStore } from '../../store'
 import { observeStore } from '../../store/observers'
 import { selectVolume } from '../../features/daw/player-bar/store/selectors'
+import {
+  dbToGain,
+  gainToDb,
+  getAudioContext,
+  getMasterGain,
+} from '../audio/engine'
 
 export class Volume {
   private _store: RootStore
 
   constructor(store: RootStore) {
     this._store = store
-
     this.registerStoreListeners()
   }
 
@@ -17,10 +21,20 @@ export class Volume {
   }
 
   setVolume(volume: number) {
-    Tone.Destination.volume.value = Volume.transformVolumeToToneVolume(volume)
+    const db = Volume.transformVolumeToToneVolume(volume)
+    const master = getMasterGain()
+    master.gain.setTargetAtTime(
+      dbToGain(db),
+      getAudioContext().currentTime,
+      0.01
+    )
   }
 
+  /**
+   * Retained name for compatibility with callers that display volume in dB.
+   * Converts the 0..N linear volume value into decibels (log scale).
+   */
   static transformVolumeToToneVolume(volume: number) {
-    return Tone.gainToDb(volume / 100)
+    return gainToDb(volume / 100)
   }
 }


### PR DESCRIPTION
Drop the ~230 KB gzipped Tone.js dependency in favor of a small, purpose-built
Web Audio engine (transport scheduler, sampler, FM synth, metronome). Bundle
goes from >500 KB (chunk-size warning) down to 309 KB (~101 KB gzipped).

Audio engine:
- src/sequencer/audio/engine.ts: single AudioContext + master GainNode, dB/gain
  helpers.
- src/sequencer/audio/transport.ts: lookahead scheduler (~25 ms, 100 ms horizon)
  with Parts, Repeats, seeking, BPM changes preserving position, and seamless
  loop wrap.
- src/sequencer/audio/buffer-cache.ts: fetch + decodeAudioData cache keyed by
  sample URL so repeated drum hits reuse the same decoded buffer.
- src/sequencer/audio/note-frequency.ts: MIDI/frequency conversion.

Instruments:
- Sampler: per-key AudioBuffer slots with nearest-neighbor fallback and
  playbackRate pitch-shift, envelope-less one-shots.
- Synth: two-operator FM voice per note with ADSR, torn down on stop.

Hot UI paths:
- Ruler: isolate the playhead into a self-subscribing component so the 160+
  ruler bars/sub-bars no longer re-render on every 16th-note tick.
- Drum pad pattern rows: React.memo + stable onSoundChange callback so only
  rows whose active-tick state changes re-render during preview playback.
- TrackList: stable per-track mute/solo callbacks via useCallback so track
  items don't re-render on unrelated dispatches.

https://claude.ai/code/session_01Dkr9TMaEwbWjJwkUqRK3Kg